### PR TITLE
Add Options Parameter to sendOptInEmail

### DIFF
--- a/pmapi/php/extra/pmapisubscriber.class.inc
+++ b/pmapi/php/extra/pmapisubscriber.class.inc
@@ -156,9 +156,11 @@ class PMAPISubscriber
      *
      * @param int $listId
      *
+     * @param array $options
+     *
      * @return int emailOptIn id
      */
-    public function sendOptInEmail($listId)
+    public function sendOptInEmail($listId, $options = array())
     {
         if (!is_numeric($listId) || $listId < 1)
         {
@@ -171,9 +173,13 @@ class PMAPISubscriber
             throw new PMAPISubscriberEmailOptInException ("Subscriber is not subscribed to list '$listId', can not send email optin.");
         }
 
-        $response = $this->request->emailOptIn->post(array(
+        $opt = array(
             'subscription_id' => $this->getListSubscriptionId($listId),
-        ));
+        );
+
+        $options = array_merge($options, $opt);
+
+        $response = $this->request->emailOptIn->post($options);
 
         if ($response->isError)
         {


### PR DESCRIPTION
This pull request allows you use options with the POST end point - [emailOptIn](https://dev.sign-up.to/documentation/reference/latest/endpoints/emailOptIn/ )

Example usage would be setting the redirectionurl for confirmed subscribers. 

```php 
$uid = 'xxxxxxxxx'; //User ID
$cid = 'xxxxxxxxx'; //Company ID
$hash = 'xxxxxxxxxx'; //Hash Value
$subscriber_id = '123456'; 
$optInOptions = array(
    'redirectionurl'=>'https://www.example.com/signup-success',
    'message_id'=>'123456'
); 
$request = new PMAPIRequest(new PMAPIAuthHash($uid, $cid, $hash));
$subscriber = new PMAPISubscriber($request,$subscriber_id);
$subscriber->sendOptInEmail($list_id, $optInOptions);
```